### PR TITLE
Fix default value for curve attributes

### DIFF
--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -190,6 +190,11 @@ const mapAttributesToOutput = (attribute) => {
     // set the default value
     if (attribute.value !== undefined) attribute.default = attribute.value;
 
+    // Curve Attributes specifically should not expose a default value if it's an empty array
+    if (attribute.type === 'curve' && Array.isArray(attribute.value) && attribute.value.length === 0) {
+        delete attribute.default;
+    }
+
     // remove typeName from the output
     delete attribute.typeName;
     delete attribute.value;

--- a/test/tests/valid/curve.test.js
+++ b/test/tests/valid/curve.test.js
@@ -27,7 +27,7 @@ describe('VALID: Curve attribute', function () {
         expect(data[0].example.attributes.a.name).to.equal('a');
         expect(data[0].example.attributes.a.type).to.equal('curve');
         expect(data[0].example.attributes.a.array).to.equal(false);
-        expect(data[0].example.attributes.a.default).to.eql([]);
+        expect(data[0].example.attributes.a.default).to.not.exist;
     });
 
     it('b: should be a curve attribute with a default value', function () {
@@ -43,7 +43,7 @@ describe('VALID: Curve attribute', function () {
         expect(data[0].example.attributes.c.name).to.equal('c');
         expect(data[0].example.attributes.c.type).to.equal('curve');
         expect(data[0].example.attributes.c.array).to.equal(false);
-        expect(data[0].example.attributes.c.default).to.eql([]);
+        expect(data[0].example.attributes.a.default).to.not.exist;
         expect(data[0].example.attributes.c.color).to.equal('r');
     });
 
@@ -52,7 +52,7 @@ describe('VALID: Curve attribute', function () {
         expect(data[0].example.attributes.d.name).to.equal('d');
         expect(data[0].example.attributes.d.type).to.equal('curve');
         expect(data[0].example.attributes.d.array).to.equal(false);
-        expect(data[0].example.attributes.d.default).to.eql([]);
+        expect(data[0].example.attributes.a.default).to.not.exist;
         expect(data[0].example.attributes.d.color).to.equal('rgb');
         expect(data[0].example.attributes.d.curves).to.deep.equal(['x', 'y', 'z']);
     });
@@ -63,7 +63,7 @@ describe('VALID: Curve attribute', function () {
         expect(data[0].example.attributes.e.type).to.equal('curve');
         expect(data[0].example.attributes.e.array).to.equal(true);
         expect(data[0].example.attributes.e.size).to.equal(2);
-        expect(data[0].example.attributes.e.default).equal(null);
+        expect(data[0].example.attributes.e.default).to.not.exist;
     });
 
     it('f: should be a curve attribute in an unsual format', function () {


### PR DESCRIPTION
This PR fixes an issue with parsing curve attributes when specified without a default value.

Currently the default behaviour is to return `{ default: []}` when no default value is defined in the code. This is inconsistent with current script parsing which expects the `default` to be excluded from the response.

This PR fixes this, so that the `default` value is not included. This fixes an upstream UI issue with the curve editor with empty  arrays.  Tests have been updated to reflect this correct behaviour