### PR TITLE
Support http/s imports

### DIFF
--- a/src/global.types.js
+++ b/src/global.types.js
@@ -1,0 +1,18 @@
+/**
+ * These types are use to extend the global types in the program being parsed.
+ * It's useful to add types to modules that are not written in TypeScript.
+ */
+
+// This allows http/s modules to be imported without TypeScript errors
+
+export default `
+declare module 'http://*' {
+  const value: any;
+  export default value;
+}
+
+declare module 'https://*' {
+  const value: any;
+  export default value;
+}
+`

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import { createSystem, createDefaultMapFromNodeModules, createVirtualTypeScriptEnvironment } from '@typescript/vfs';
-
+import globalTypes from './global.types.js';
 import { ScriptParser } from './parsers/script-parser.js';
 import { createDefaultMapFromCDN, flatMapAnyNodes, getExportedNodes, getType, inheritsFrom, isAliasedClassDeclaration } from './utils/ts-utils.js';
 
@@ -8,6 +8,7 @@ const toLowerCamelCase = str => str[0].toLowerCase() + str.substring(1);
 
 const COMPILER_OPTIONS = {
     strictPropertyInitialization: false, // Allow uninitialized properties
+    skipLibCheck: true, // Skip type checking of declaration files
     target: ts.ScriptTarget.ES2022, // If this version changes, the types must be updated in the /rollup.config.mjs
     module: ts.ModuleKind.CommonJS,
     checkJs: true, // Enable JSDoc parsing
@@ -47,6 +48,10 @@ export class JSDocParser {
         // Set up the virtual file system and environment
         const system = createSystem(fsMap);
         this._env = createVirtualTypeScriptEnvironment(system, Array.from(fsMap.keys()), ts, COMPILER_OPTIONS);
+
+        // Add global types to the parser
+        this._env.createFile('/global.d.ts', globalTypes);
+
     }
 
     /**

--- a/test/fixtures/asset.invalid.js
+++ b/test/fixtures/asset.invalid.js
@@ -21,6 +21,7 @@ class Example extends Script {
      * @resource
      */
     c;
+
 }
 
 export { Example };

--- a/test/fixtures/program.valid.js
+++ b/test/fixtures/program.valid.js
@@ -1,0 +1,18 @@
+import { Script } from 'playcanvas';
+
+// The parser should ignore https imports and not throw an error
+import confetti from "https://esm.sh/canvas-confetti@1.6.0"
+
+class Example extends Script {
+    /**
+     * @attribute
+     * @type {boolean}
+     */
+    a = false;
+
+    initialize() {
+        confetti();
+    }
+}
+
+export { Example };

--- a/test/tests/valid/program.test.js
+++ b/test/tests/valid/program.test.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-unused-expressions */
+import { describe, it, before } from 'mocha';
+import { expect } from 'chai';
+
+import { parseAttributes } from '../../utils.js';
+
+describe('VALID: Program ', function () {
+    let data;
+    before(async function () {
+        data = await parseAttributes('./program.valid.js');
+    });
+
+    it('only results should exist', function () {
+        expect(data).to.exist;
+        expect(data[0]).to.not.be.empty;
+        expect(data[1]).to.be.empty;
+    });
+});


### PR DESCRIPTION
This PR adds support for parsing code that contains explicit external http/s imports.

Previously the following would fail in the parser because the types for the external modules could not be determined
```javascript
import { Script } from 'playcanvas';
import confetti from "https://esm.sh/canvas-confetti@1.6.0"

export class Example extends Script {
    initialize() {
        confetti();
    }
}
```

https/s module imports are now implicitly treated as `any`, which allows the parser to effectively ignore them. This fixes #2. Test also added

