### PR TITLE
Fixes Enum check

### DIFF
--- a/src/utils/ts-utils.js
+++ b/src/utils/ts-utils.js
@@ -86,7 +86,7 @@ export function isAliasedClassDeclaration(node, typeChecker) {
         return true;
     }
     // Try to resolve the original declaration
-    if (ts.isIdentifier(node.name)) {
+    if (node?.name && ts.isIdentifier(node.name)) {
         const symbol = typeChecker.getSymbolAtLocation(node.name);
         if (symbol) {
             const resolvedSymbol = resolveAliasedSymbol(typeChecker, symbol);

--- a/test/fixtures/program.valid.js
+++ b/test/fixtures/program.valid.js
@@ -2,6 +2,9 @@ import * as TWEEN from 'https://cdnjs.cloudflare.com/ajax/libs/tween.js/23.1.2/t
 import confetti from 'https://esm.sh/canvas-confetti@1.6.0';
 import { Script } from 'playcanvas';
 
+/** @enum {number} */
+export const MyEnum = { value: 0 }
+
 class Example extends Script {
     /**
      * @attribute

--- a/test/fixtures/program.valid.js
+++ b/test/fixtures/program.valid.js
@@ -3,7 +3,7 @@ import confetti from 'https://esm.sh/canvas-confetti@1.6.0';
 import { Script } from 'playcanvas';
 
 /** @enum {number} */
-export const MyEnum = { value: 0 }
+export const MyEnum = { value: 0 };
 
 class Example extends Script {
     /**


### PR DESCRIPTION
Fixes an issue parsing a Script where exporting both an enum and Script would fail in the parser

```javascript
// This would fail
/** @enum {number} */
import { Script } from 'playcanvas';
export const MyEnum = { value: 0 };
export class MyScript extends Script {};
```

Included the condition in the `./program.valid.js` test