### PR TITLE
Scoped Tag Validation

### DIFF
--- a/src/utils/tag-utils.js
+++ b/src/utils/tag-utils.js
@@ -1,4 +1,4 @@
-import { DiagnosticCategory, flattenDiagnosticMessageText } from 'typescript';
+import { DiagnosticCategory } from 'typescript';
 
 import { parseNumber, parseStringToNumericalArray } from './ts-utils.js';
 

--- a/src/utils/tag-utils.js
+++ b/src/utils/tag-utils.js
@@ -1,3 +1,5 @@
+import { DiagnosticCategory, flattenDiagnosticMessageText } from 'typescript';
+
 import { parseNumber, parseStringToNumericalArray } from './ts-utils.js';
 
 /**
@@ -35,15 +37,15 @@ export function parseTag(input = '') {
 
 /**
  * Validates that a tag value matches the expected type
- * 
- * @param value - The value to be validated.
- * @param typeAnnotation - The TypeScript type annotation as a string.
- * @param env - The environment containing the language service and file creation utilities.
+ *
+ * @param {String} value - The value to be validated.
+ * @param {String} typeAnnotation - The TypeScript type annotation as a string.
+ * @param {import('@typescript/vfs').VirtualTypeScriptEnvironment} env - The environment containing the language service and file creation utilities.
  * @throws Will throw an error if the value does not conform to the typeAnnotation.
- * @returns `true` if validation passes without type errors.
+ * @returns {true} if validation passes without type errors.
  */
 export function validateTag(value, typeAnnotation, env) {
-    const virtualFileName = "/___virtual__.ts";
+    const virtualFileName = '/___virtual__.ts';
     const sourceText = `let a: ${typeAnnotation} = ${value};`;
 
     // Create or overwrite the virtual file with the new source text
@@ -57,16 +59,12 @@ export function validateTag(value, typeAnnotation, env) {
 
     // Filter for type assignment errors (Error Code 2322: Type 'X' is not assignable to type 'Y')
     const typeErrors = errors.filter(
-        error => error.code === 2322 && error.category === ts.DiagnosticCategory.Error
+        error => error.code === 2322 && error.category === DiagnosticCategory.Error
     );
 
     // If any type error is found, throw an error with the diagnostic message
     if (typeErrors.length > 0) {
-        // TypeScript's messageText can be a string or a DiagnosticMessageChain
-        const errorMessage = typeErrors[0].messageText instanceof ts.DiagnosticMessageChain
-            ? flattenDiagnosticMessageText(typeErrors[0].messageText, "\n")
-            : typeErrors[0].messageText.toString();
-
+        const errorMessage = typeErrors[0].messageText.toString();
         throw new Error(`Type Validation Error: ${errorMessage}`);
     }
 

--- a/test/fixtures/program.valid.js
+++ b/test/fixtures/program.valid.js
@@ -8,13 +8,17 @@ export const MyEnum = { value: 0 };
 class Example extends Script {
     /**
      * @attribute
-     * @type {boolean}
+     * @precision 1
+     * @type {number}
      */
-    a = false;
+    a;
 
     initialize() {
         confetti();
         new TWEEN.Tween({ x: 0 }).to({ x: 100 }, 1000).start();
+
+        // This is an intentional type error, but the parser should ignore these
+        this.a = 'string';
     }
 }
 

--- a/test/tests/valid/program.test.js
+++ b/test/tests/valid/program.test.js
@@ -13,5 +13,6 @@ describe('VALID: Program ', function () {
         expect(data).to.exist;
         expect(data[0]).to.not.be.empty;
         expect(data[1]).to.be.empty;
+        expect(data[0].example.errors).to.be.empty;
     });
 });


### PR DESCRIPTION
Ensures any errors reported whilst validating jsdoc tags  ie `@range`, `@precision` and `@step` contain the correct relevant errors for the target file and not other semantic program errors unrelated to the current file. Fixes #13 

Includes test coverage

Also adds some better code documentation.
