### PR TITLE
Adds Support for Enum refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mocha": "^10.6.0"
   },
   "scripts": {
-    "test": "mocha test/**/*.test.js --timeout 10000",
+    "test": "mocha test/**/valid/enum.test.js --timeout 10000",
     "lint": "eslint ."
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mocha": "^10.6.0"
   },
   "scripts": {
-    "test": "mocha test/**/valid/enum.test.js --timeout 10000",
+    "test": "mocha test/**/*.test.js --timeout 10000",
     "lint": "eslint ."
   },
   "publishConfig": {

--- a/src/parsers/attribute-parser.js
+++ b/src/parsers/attribute-parser.js
@@ -170,7 +170,7 @@ export class AttributeParser {
         const serializer = !array && this.typeSerializerMap.get(type);
         if (serializer) {
             try {
-                value = serializer(node.initializer ?? node);
+                value = serializer(node.initializer ?? node, this.typeChecker);
             } catch (error) {
                 errors.push(error);
                 return;

--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -187,6 +187,13 @@ const mapAttributesToOutput = (attribute) => {
     // remove enum if it's empty
     if (attribute.enum.length === 0) delete attribute.enum;
 
+    // If the attribute has no default value then set it
+    if (attribute.value === undefined) {
+        if(attribute.type === 'string') attribute.value = '';
+        if(attribute.type === 'number') attribute.value = 0;
+        if(attribute.type === 'boolean') attribute.value = false;
+    }
+
     // set the default value
     if (attribute.value !== undefined) attribute.default = attribute.value;
 

--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -5,7 +5,7 @@ import { AttributeParser } from './attribute-parser.js';
 import { ParsingError } from './parsing-error.js';
 import { hasTag } from '../utils/attribute-utils.js';
 import { zipArrays } from '../utils/generic-utils.js';
-import { flatMapAnyNodes, getJSDocCommentRanges, parseArrayLiteral, parseBooleanNode, parseFloatNode, parseStringNode } from '../utils/ts-utils.js';
+import { flatMapAnyNodes, getJSDocCommentRanges, getLiteralValue, parseArrayLiteral, parseBooleanNode, parseFloatNode, parseStringNode } from '../utils/ts-utils.js';
 
 /**
  * @typedef {object} Attribute
@@ -77,9 +77,9 @@ const SUPPORTED_INITIALIZABLE_TYPE_NAMES = new Map([
     ['Vec3', createNumberArgumentParser('Vec3', [0, 0, 0])],
     ['Vec4', createNumberArgumentParser('Vec4', [0, 0, 0, 0])],
     ['Color', createNumberArgumentParser('Color', [1, 1, 1, 1])],
-    ['number', parseFloatNode],
-    ['string', parseStringNode],
-    ['boolean', parseBooleanNode]
+    ['number', getLiteralValue],
+    ['string', getLiteralValue],
+    ['boolean', getLiteralValue]
 ]);
 
 /**

--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -5,7 +5,7 @@ import { AttributeParser } from './attribute-parser.js';
 import { ParsingError } from './parsing-error.js';
 import { hasTag } from '../utils/attribute-utils.js';
 import { zipArrays } from '../utils/generic-utils.js';
-import { flatMapAnyNodes, getJSDocCommentRanges, getLiteralValue, parseArrayLiteral, parseBooleanNode, parseFloatNode, parseStringNode } from '../utils/ts-utils.js';
+import { flatMapAnyNodes, getJSDocCommentRanges, getLiteralValue, parseArrayLiteral, parseFloatNode } from '../utils/ts-utils.js';
 
 /**
  * @typedef {object} Attribute
@@ -189,9 +189,9 @@ const mapAttributesToOutput = (attribute) => {
 
     // If the attribute has no default value then set it
     if (attribute.value === undefined) {
-        if(attribute.type === 'string') attribute.value = '';
-        if(attribute.type === 'number') attribute.value = 0;
-        if(attribute.type === 'boolean') attribute.value = false;
+        if (attribute.type === 'string') attribute.value = '';
+        if (attribute.type === 'number') attribute.value = 0;
+        if (attribute.type === 'boolean') attribute.value = false;
     }
 
     // set the default value

--- a/src/utils/ts-utils.js
+++ b/src/utils/ts-utils.js
@@ -474,7 +474,15 @@ function resolveIdentifier(node, typeChecker) {
     return undefined;
 }
 
-function resolvePropertyAccess(node, typeChecker) {
+/**
+ * Resolve the value of a property access expression. Limited to simple cases like
+ * object literals and variable declarations.
+ * 
+ * @param {import('typescript').Node} node - The property access expression node
+ * @param {import('typescript')} typeChecker - The TypeScript type checker
+ * @returns {any} - The resolved value of the property access
+ */
+const resolvePropertyAccess = (node, typeChecker) => {
     const symbol = typeChecker.getSymbolAtLocation(node);
     if (symbol && symbol.declarations) {
         for (const declaration of symbol.declarations) {
@@ -498,7 +506,13 @@ function resolvePropertyAccess(node, typeChecker) {
     return undefined;
 }
 
-function evaluatePrefixUnaryExpression(node, typeChecker) {
+/**
+ * Evaluates unary prefixes like +, -, !, ~, and returns the result.
+ * @param {import('typescript').Node} node - The AST node to evaluate
+ * @param {import('typescript').TypeChecker} typeChecker - The TypeScript type checker
+ * @returns {number | boolean | undefined} - The result of the evaluation
+ */
+const evaluatePrefixUnaryExpression = (node, typeChecker) => {
     const operandValue = getLiteralValue(node.operand, typeChecker);
     if (operandValue !== undefined) {
         switch (node.operator) {
@@ -531,7 +545,15 @@ function handleObjectLiteral(node, typeChecker) {
     return obj;
 }
 
-// Modify getLiteralValue to handle ObjectLiteralExpression
+/**
+ * Attempts to extract a literal value from a TypeScript node. This function
+ * supports various types of literals and expressions, including object literals,
+ * array literals, identifiers, and unary expressions.
+ * 
+ * @param {import('typescript').Node} node - The AST node to evaluate
+ * @param {import('typescript').TypeChecker} typeChecker - The TypeScript type checker
+ * @returns {any} - The extracted literal value
+ */
 export function getLiteralValue(node, typeChecker) {
     if (!node) return undefined;
 

--- a/src/utils/ts-utils.js
+++ b/src/utils/ts-utils.js
@@ -477,7 +477,7 @@ function resolveIdentifier(node, typeChecker) {
 /**
  * Resolve the value of a property access expression. Limited to simple cases like
  * object literals and variable declarations.
- * 
+ *
  * @param {import('typescript').Node} node - The property access expression node
  * @param {import('typescript')} typeChecker - The TypeScript type checker
  * @returns {any} - The resolved value of the property access
@@ -504,7 +504,7 @@ const resolvePropertyAccess = (node, typeChecker) => {
     }
 
     return undefined;
-}
+};
 
 /**
  * Evaluates unary prefixes like +, -, !, ~, and returns the result.
@@ -527,7 +527,7 @@ const evaluatePrefixUnaryExpression = (node, typeChecker) => {
         }
     }
     return undefined;
-}
+};
 
 function handleObjectLiteral(node, typeChecker) {
     const obj = {};
@@ -549,7 +549,7 @@ function handleObjectLiteral(node, typeChecker) {
  * Attempts to extract a literal value from a TypeScript node. This function
  * supports various types of literals and expressions, including object literals,
  * array literals, identifiers, and unary expressions.
- * 
+ *
  * @param {import('typescript').Node} node - The AST node to evaluate
  * @param {import('typescript').TypeChecker} typeChecker - The TypeScript type checker
  * @returns {any} - The extracted literal value

--- a/src/utils/ts-utils.js
+++ b/src/utils/ts-utils.js
@@ -461,6 +461,115 @@ export const parseBooleanNode = (node) => {
     return node.kind === ts.SyntaxKind.TrueKeyword;
 };
 
+function resolveIdentifier(node, typeChecker) {
+    const symbol = typeChecker.getSymbolAtLocation(node);
+    if (symbol && symbol.declarations) {
+        for (const declaration of symbol.declarations) {
+            if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+                return getLiteralValue(declaration.initializer, typeChecker);
+            }
+            // Handle other kinds of declarations if needed
+        }
+    }
+    return undefined;
+}
+
+function resolvePropertyAccess(node, typeChecker) {
+    const symbol = typeChecker.getSymbolAtLocation(node);
+    if (symbol && symbol.declarations) {
+        for (const declaration of symbol.declarations) {
+            if (ts.isPropertyAssignment(declaration) && declaration.initializer) {
+                return getLiteralValue(declaration.initializer, typeChecker);
+            }
+            if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+                return getLiteralValue(declaration.initializer, typeChecker);
+            }
+            // Handle other kinds of declarations if needed
+        }
+    }
+
+    // If symbol not found directly, attempt to resolve the object first
+    const objValue = getLiteralValue(node.expression, typeChecker);
+    if (objValue && typeof objValue === 'object') {
+        const propName = node.name.text;
+        return objValue[propName];
+    }
+
+    return undefined;
+}
+
+function evaluatePrefixUnaryExpression(node, typeChecker) {
+    const operandValue = getLiteralValue(node.operand, typeChecker);
+    if (operandValue !== undefined) {
+        switch (node.operator) {
+            case ts.SyntaxKind.PlusToken:
+                return +operandValue;
+            case ts.SyntaxKind.MinusToken:
+                return -operandValue;
+            case ts.SyntaxKind.ExclamationToken:
+                return !operandValue;
+            case ts.SyntaxKind.TildeToken:
+                return ~operandValue;
+        }
+    }
+    return undefined;
+}
+
+function handleObjectLiteral(node, typeChecker) {
+    const obj = {};
+    node.properties.forEach(prop => {
+        if (ts.isPropertyAssignment(prop)) {
+            const key = prop.name.getText();
+            const value = getLiteralValue(prop.initializer, typeChecker);
+            obj[key] = value;
+        } else if (ts.isShorthandPropertyAssignment(prop)) {
+            const key = prop.name.getText();
+            const value = resolveIdentifier(prop.name, typeChecker);
+            obj[key] = value;
+        }
+    });
+    return obj;
+}
+
+// Modify getLiteralValue to handle ObjectLiteralExpression
+export function getLiteralValue(node, typeChecker) {
+    if (!node) return undefined;
+
+    if (ts.isLiteralExpression(node)) {
+        if (ts.isStringLiteral(node)) {
+            return node.text;
+        }
+        if (ts.isNumericLiteral(node)) {
+            return Number(node.text);
+        }
+        if (node.kind === ts.SyntaxKind.TrueKeyword) {
+            return true;
+        }
+        if (node.kind === ts.SyntaxKind.FalseKeyword) {
+            return false;
+        }
+    }
+
+    switch (node.kind) {
+        case ts.SyntaxKind.NullKeyword:
+            return null;
+        case ts.SyntaxKind.ArrayLiteralExpression:
+            return (node).elements.map(element => getLiteralValue(element, typeChecker));
+        case ts.SyntaxKind.ObjectLiteralExpression:
+            return handleObjectLiteral(node, typeChecker);
+        case ts.SyntaxKind.Identifier:
+            return resolveIdentifier(node, typeChecker);
+        case ts.SyntaxKind.PropertyAccessExpression:
+            return resolvePropertyAccess(node, typeChecker);
+        case ts.SyntaxKind.ParenthesizedExpression:
+            return getLiteralValue((node).expression, typeChecker);
+        case ts.SyntaxKind.PrefixUnaryExpression:
+            return evaluatePrefixUnaryExpression(node, typeChecker);
+        default:
+            return undefined;
+    }
+}
+
 /**
  * If the given node is a string literal, returns the parsed string.
  * @param {import('typescript').Node} node - The node to check

--- a/src/utils/ts-utils.js
+++ b/src/utils/ts-utils.js
@@ -535,7 +535,7 @@ function handleObjectLiteral(node, typeChecker) {
 export function getLiteralValue(node, typeChecker) {
     if (!node) return undefined;
 
-    if (ts.isLiteralExpression(node)) {
+    if (ts.isLiteralExpression(node) || ts.isBooleanLiteral(node)) {
         if (ts.isStringLiteral(node)) {
             return node.text;
         }

--- a/src/utils/ts-utils.js
+++ b/src/utils/ts-utils.js
@@ -517,7 +517,7 @@ function evaluatePrefixUnaryExpression(node, typeChecker) {
 
 function handleObjectLiteral(node, typeChecker) {
     const obj = {};
-    node.properties.forEach(prop => {
+    node.properties.forEach((prop) => {
         if (ts.isPropertyAssignment(prop)) {
             const key = prop.name.getText();
             const value = getLiteralValue(prop.initializer, typeChecker);

--- a/test/fixtures/enum.valid.js
+++ b/test/fixtures/enum.valid.js
@@ -44,7 +44,7 @@ class Example extends Script {
      * @attribute
      * @type {NumberEnum}
      */
-    e;
+    e = NumberEnum.A;
 
     /**
      * @attribute


### PR DESCRIPTION
Adds support for enum attributes by reference. Fixes #12 .

Both the following using literal and reference are now supported. Tests updated to include both use cases.

```javascript
import { Script } from 'playcanvas'

/** @enum {number} */
const Lights = {
    ON: 1,
    OFF: 0,
    UNKNOWN: 0.5
}

class Hack extends Script {
    /**
     * @attribute
     * @type {Lights}
     */
    ambient = Lights.OFF
    
    /**
     * @attribute
     * @type {Lights}
     */
    spec = 0
}

export { Hack };
```