### PR TITLE
String Enum Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/attribute-parser",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/attribute-parser",
-      "version": "1.0.8",
+      "version": "1.1.0",
       "dependencies": {
         "@microsoft/tsdoc": "^0.15.0",
         "@playcanvas/eslint-config": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "version": "1.0.8",
+  "version": "1.1.0",
   "dependencies": {
     "@microsoft/tsdoc": "^0.15.0",
     "@playcanvas/eslint-config": "^1.7.4",

--- a/src/parsers/attribute-parser.js
+++ b/src/parsers/attribute-parser.js
@@ -256,21 +256,7 @@ export class AttributeParser {
 
                 if (ts.isPropertyAssignment(property)) {
                     const name = property.name && ts.isIdentifier(property.name) && property.name.text;
-                    let value;
-
-                    const node = property.initializer;
-
-                    value = getLiteralValue(node, this.typeChecker);
-
-                    // Enums can only contain primitives (string|number|boolean)
-                    // if (ts.isNumericLiteral(node)) {
-                    //     value = parseFloat(node.getText());
-                    // } else if (node.kind === ts.SyntaxKind.TrueKeyword || node.kind === ts.SyntaxKind.FalseKeyword) {
-                    //     value = node.kind === ts.SyntaxKind.TrueKeyword;
-                    // } else {
-                    //     value = node.getText();
-                    // }
-
+                    const value = getLiteralValue(property.initializer, this.typeChecker);
                     members.push({ [name]: value });
                 }
             });

--- a/src/parsers/attribute-parser.js
+++ b/src/parsers/attribute-parser.js
@@ -4,7 +4,7 @@ import * as ts from 'typescript';
 import { ParsingError } from './parsing-error.js';
 import { hasTag } from '../utils/attribute-utils.js';
 import { parseTag, validateTag } from '../utils/tag-utils.js';
-import { extractTextFromDocNode, getLeadingBlockCommentRanges, getType } from '../utils/ts-utils.js';
+import { extractTextFromDocNode, getLeadingBlockCommentRanges, getLiteralValue, getType } from '../utils/ts-utils.js';
 
 /**
  * A class to parse JSDoc comments and extract attribute metadata.
@@ -260,14 +260,16 @@ export class AttributeParser {
 
                     const node = property.initializer;
 
+                    value = getLiteralValue(node, this.typeChecker);
+
                     // Enums can only contain primitives (string|number|boolean)
-                    if (ts.isNumericLiteral(node)) {
-                        value = parseFloat(node.getText());
-                    } else if (node.kind === ts.SyntaxKind.TrueKeyword || node.kind === ts.SyntaxKind.FalseKeyword) {
-                        value = node.kind === ts.SyntaxKind.TrueKeyword;
-                    } else {
-                        value = node.getText();
-                    }
+                    // if (ts.isNumericLiteral(node)) {
+                    //     value = parseFloat(node.getText());
+                    // } else if (node.kind === ts.SyntaxKind.TrueKeyword || node.kind === ts.SyntaxKind.FalseKeyword) {
+                    //     value = node.kind === ts.SyntaxKind.TrueKeyword;
+                    // } else {
+                    //     value = node.getText();
+                    // }
 
                     members.push({ [name]: value });
                 }

--- a/test/fixtures/enum.valid.js
+++ b/test/fixtures/enum.valid.js
@@ -4,9 +4,9 @@ import { Script, Vec3 } from 'playcanvas';
  * @enum {number}
  */
 const NumberEnum = {
-    A: 0,
-    B: 1,
-    C: 2
+    A: 13,
+    B: 14,
+    C: 23
 };
 
 /**

--- a/test/tests/valid/enum.test.js
+++ b/test/tests/valid/enum.test.js
@@ -51,7 +51,7 @@ describe('VALID: Enum attribute', function () {
         expect(data[0].example.attributes.h.name).to.equal('h');
         expect(data[0].example.attributes.h.type).to.equal('string');
         expect(data[0].example.attributes.h.array).to.equal(false);
-        expect(data[0].example.attributes.h.enum).to.be.an('array').with.lengthOf(3)
+        expect(data[0].example.attributes.h.enum).to.be.an('array').with.lengthOf(3);
         expect(data[0].example.attributes.h.enum[0]).to.deep.equal({ A: 'a' });
         expect(data[0].example.attributes.h.enum[1]).to.deep.equal({ B: 'b' });
         expect(data[0].example.attributes.h.enum[2]).to.deep.equal({ C: 'c' });

--- a/test/tests/valid/enum.test.js
+++ b/test/tests/valid/enum.test.js
@@ -26,7 +26,7 @@ describe('VALID: Enum attribute', function () {
         expect(data[0].example.attributes.e.name).to.equal('e');
         expect(data[0].example.attributes.e.type).to.equal('number');
         expect(data[0].example.attributes.e.array).to.equal(false);
-        expect(data[0].example.attributes.e.default).to.equal(0);
+        expect(data[0].example.attributes.e.default).to.equal(13);
     });
 
     it('f: should be a enum attribute with a default value', function () {
@@ -51,6 +51,10 @@ describe('VALID: Enum attribute', function () {
         expect(data[0].example.attributes.h.name).to.equal('h');
         expect(data[0].example.attributes.h.type).to.equal('string');
         expect(data[0].example.attributes.h.array).to.equal(false);
+        expect(data[0].example.attributes.h.enum).to.be.an('array').with.lengthOf(3)
+        expect(data[0].example.attributes.h.enum[0]).to.deep.equal({ A: 'a' });
+        expect(data[0].example.attributes.h.enum[1]).to.deep.equal({ B: 'b' });
+        expect(data[0].example.attributes.h.enum[2]).to.deep.equal({ C: 'c' });
         expect(data[0].example.attributes.h.default).to.equal('');
     });
 


### PR DESCRIPTION
Fixes an issue with string enums that would return an incorrect value. Previously when parsing the following script 

```javascript
/** @enum */
const StringEnum = { A = "a"  }

class MyScript {
  /** 
   * @attribute
   * @type {StringEnum}
   */
   str;
}
```

The parser would return this enum schema `{ enum: [{ A : '"a"'}]}` (notice the 'a' wrapped in nested quotations)

This PR fixes this and  adds missing tests around this case.
