### PR TITLE
Support Single Types file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/attribute-parser",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/attribute-parser",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@microsoft/tsdoc": "^0.15.0",
         "@playcanvas/eslint-config": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "version": "1.1.0",
+  "version": "1.2.0",
   "dependencies": {
     "@microsoft/tsdoc": "^0.15.0",
     "@playcanvas/eslint-config": "^1.7.4",

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export class JSDocParser {
     /**
      * Initializes the JSDocParser with the standard library files
      *
-     * @param {string} libPath - The path to standard library files
+     * @param {string} libPath - A path to a directory of library types, or a path to the '.d.ts' file itself
      * @returns {Promise<JSDocParser>} - The initialized JSDocParser
      */
     async init(libPath) {
@@ -46,12 +46,21 @@ export class JSDocParser {
         }
 
         let fsMap;
-        // This is a node only option. If no lib path is passed, attempt to resolve ES types from node_modules.
         if (!libPath) {
+
+            // This is a node only option. If no lib path is passed, attempt to resolve ES types from node_modules.
             fsMap = await createDefaultMapFromNodeModules(COMPILER_OPTIONS, ts);
-        } else {
+
+        } else if(libPath.endsWith('.d.ts')) {
+
+            // If the libPath is a '.d.ts' file then load it and add it
             const types = await fetch(libPath).then(r => r.text());
             fsMap = new Map([['/lib.d.ts', types]]);
+
+        } else {
+
+            // A libPath was supplied, but not to a '.d.ts', so assume this is a path to types
+            fsMap = await createDefaultMapFromCDN(COMPILER_OPTIONS, libPath, ts);
         }
 
         // Set up the virtual file system and environment

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export class JSDocParser {
             // This is a node only option. If no lib path is passed, attempt to resolve ES types from node_modules.
             fsMap = await createDefaultMapFromNodeModules(COMPILER_OPTIONS, ts);
 
-        } else if(libPath.endsWith('.d.ts')) {
+        } else if (libPath.endsWith('.d.ts')) {
 
             // If the libPath is a '.d.ts' file then load it and add it
             const types = await fetch(libPath).then(r => r.text());


### PR DESCRIPTION
Previously the parser would be initialized with a directory path from which to load types

```javascript
new Parser().init('/path/to/types/dir/');
```
The dom types are in seperate files, which would result in ~80 network request to various files.

This PR extends the api so that a path to a single file can be used instead, which allows for a single file to be loaded that represents all the types neccessary

```javascript
new Parser().init('/path/to/types/dir/lib.d.ts');
```