### PR TITLE
Support Inherited Attributes across files

### DIFF
--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -321,17 +321,19 @@ export class ScriptParser {
             return attributes;
         }
 
-        const buffer = node.getSourceFile().getFullText();
+        // const buffer = node.getSourceFile().getFullText();
 
         // Find "/** */" style comments associated with this node.
-        const comments = getJSDocCommentRanges(node, buffer, this.typeChecker);
+        const comments = getJSDocCommentRanges(node, this.typeChecker);
 
         // Parse the comments for attribute metadata
         for (const comment of comments) {
 
+            const memberFileText = comment.member.getSourceFile().getFullText();
+
             // Parse the comment for attribute metadata
             const attributeMetadata = this.attributeParser.parseAttributeComment(
-                TextRange.fromStringRange(buffer, comment.range.pos, comment.range.end),
+                TextRange.fromStringRange(memberFileText, comment.range.pos, comment.range.end),
                 comment.member,
                 errors,
                 requiresAttributeTag

--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -321,8 +321,6 @@ export class ScriptParser {
             return attributes;
         }
 
-        // const buffer = node.getSourceFile().getFullText();
-
         // Find "/** */" style comments associated with this node.
         const comments = getJSDocCommentRanges(node, this.typeChecker);
 

--- a/src/utils/ts-utils.js
+++ b/src/utils/ts-utils.js
@@ -205,12 +205,13 @@ function getSuperClasses(node, typeChecker) {
  * @param {import('typescript').TypeChecker} typeChecker - The TypeScript type checker
  * @returns {{ memberName: string, member: ts.Node, range: import('typescript').CommentRange}[]} - An array of comment ranges
  */
-export function getJSDocCommentRanges(node, text, typeChecker) {
+export function getJSDocCommentRanges(node, typeChecker) {
     const commentRanges = [];
 
     if (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) {
         // get an array of the class an all parent classed
-        const heritageChain = getSuperClasses(node, typeChecker);
+        const heritageChain = getSuperClasses(node, typeChecker)
+        .filter(classNode => !classNode.getSourceFile().isDeclarationFile)
 
         // iterate over the heritance chain
         heritageChain.forEach((classNode) => {
@@ -218,7 +219,7 @@ export function getJSDocCommentRanges(node, text, typeChecker) {
             classNode.members.forEach((member) => {
                 if (ts.isPropertyDeclaration(member) || ts.isSetAccessor(member) || ts.isPropertySignature(member)) {
                     const memberName = member.name && ts.isIdentifier(member.name) ? member.name.text : 'unnamed';
-                    const ranges = getLeadingBlockCommentRanges(member, text);
+                    const ranges = getLeadingBlockCommentRanges(member, member.getSourceFile().getFullText());
                     if (ranges.length > 0) {
                         commentRanges.push({
                             memberName,

--- a/src/utils/ts-utils.js
+++ b/src/utils/ts-utils.js
@@ -211,7 +211,7 @@ export function getJSDocCommentRanges(node, typeChecker) {
     if (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) {
         // get an array of the class an all parent classed
         const heritageChain = getSuperClasses(node, typeChecker)
-        .filter(classNode => !classNode.getSourceFile().isDeclarationFile)
+        .filter(classNode => !classNode.getSourceFile().isDeclarationFile);
 
         // iterate over the heritance chain
         heritageChain.forEach((classNode) => {

--- a/test/fixtures/example.dep.js
+++ b/test/fixtures/example.dep.js
@@ -1,4 +1,4 @@
-import { Script } from 'playcanvas'
+import { Script } from 'playcanvas';
 
 export class Example extends Script {
     /**

--- a/test/fixtures/example.dep.js
+++ b/test/fixtures/example.dep.js
@@ -1,0 +1,9 @@
+import { Script } from 'playcanvas'
+
+export class Example extends Script {
+    /**
+     * @attribute
+     * @type {boolean}
+     */
+    a;
+}

--- a/test/fixtures/inherit.valid.js
+++ b/test/fixtures/inherit.valid.js
@@ -1,4 +1,5 @@
 import { Script } from 'playcanvas';
+
 import { Example } from './example.dep.js';
 
 class ExampleExtended extends Example {

--- a/test/fixtures/inherit.valid.js
+++ b/test/fixtures/inherit.valid.js
@@ -1,12 +1,5 @@
 import { Script } from 'playcanvas';
-
-class Example extends Script {
-    /**
-     * @attribute
-     * @type {boolean}
-     */
-    a;
-}
+import { Example } from './example.dep.js';
 
 class ExampleExtended extends Example {
     /**

--- a/test/tests/valid/inherit.test.js
+++ b/test/tests/valid/inherit.test.js
@@ -24,6 +24,14 @@ describe('VALID: Script inheritance attributes', function () {
     it('ExampleExtended: should exist without errors', function () {
         expect(data[0]?.exampleExtended).to.exist;
         expect(data[0].exampleExtended.attributes).to.not.be.empty;
+        expect(data[0].exampleExtended.attributes.a).to.exist;
+        expect(data[0].exampleExtended.attributes.a.type).to.equal('boolean');
+        expect(data[0].exampleExtended.attributes.a.array).to.equal(false);
+        expect(data[0].exampleExtended.attributes.a.default).to.equal(false);
+        expect(data[0].exampleExtended.attributes.b).to.be.exists;
+        expect(data[0].exampleExtended.attributes.b.type).to.equal('number');
+        expect(data[0].exampleExtended.attributes.b.array).to.equal(false);
+        expect(data[0].exampleExtended.attributes.b.default).to.equal(0);
         expect(data[0].exampleExtended.errors).to.be.empty;
     });
 

--- a/test/tests/valid/inherit.test.js
+++ b/test/tests/valid/inherit.test.js
@@ -6,7 +6,7 @@ import { parseAttributes } from '../../utils.js';
 describe('VALID: Script inheritance attributes', function () {
     let data;
     before(async function () {
-        data = await parseAttributes('./inherit.valid.js');
+        data = await parseAttributes('./inherit.valid.js', './example.dep.js');
     });
 
     it('only results should exist', function () {


### PR DESCRIPTION
This PR adds support to extend ESM Scripts in relative modules and inherit their attributes. 

This means you can declare a base class in one file, extend it in another and inherit it's attributes.

Fixes #20. Tests included.

```javascript
// "./rotator.js"
import { Script } from 'playcanvas';

export class Rotator extends Script {
    /**
     * @attribute
     * You can now set the `speed`property dynamically in the editor
     */
    speed = 2;

    update(dt){
        this.entity.rotateLocal(0, this.speed * dt, 0)
    }
}

// "./double-fast-rotator.mjs"
import {Rotator} from './rotator.mjs'

export class DoubleFastRotator extends Rotator {
    update(dt){
        this.entity.rotateLocal(0, this.speed * dt * 2, 0)
    }
}
```