### PR TITLE
Allow empty files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,8 +123,16 @@ export class JSDocParser {
             throw new Error('PlayCanvas Types must be supplied');
         }
 
+        const esmScripts = new Map();
+
         // Parse the source file and pc types
         const sourceFile = this.program.getSourceFile(fileName);
+
+        // In a special edge case where the files contents are empty, the sourcefile will be undefined
+        // So we should early out
+        if (sourceFile === undefined) {
+            return esmScripts;
+        }
 
         if (!sourceFile) {
             throw new Error(`Source file ${fileName} not found`);
@@ -135,7 +143,6 @@ export class JSDocParser {
 
         const esmScriptClass = pcTypes.statements.find(node => node.kind === ts.SyntaxKind.ClassDeclaration && node.name.text === 'Script')?.symbol;
 
-        const esmScripts = new Map();
         // Check if the file exports a class that inherits from `Script`
         nodes.forEach((node, name) => {
             if (isAliasedClassDeclaration(node, typeChecker) && inheritsFrom(node, typeChecker, esmScriptClass)) {

--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ export class JSDocParser {
             return esmScripts;
         }
 
-        if (!sourceFile) {
+        if (sourceFile === null) {
             throw new Error(`Source file ${fileName} not found`);
         }
 

--- a/test/tests/valid/empty.test.js
+++ b/test/tests/valid/empty.test.js
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { describe, it, before } from 'mocha';
+
+import { parseAttributes } from '../../utils.js';
+
+describe('VALID: Program ', function () {
+    let data;
+    before(async function () {
+        data = await parseAttributes('./empty.valid.js');
+    });
+
+    it('only results should exist', function () {
+        expect(data).to.exist;
+        expect(data[0]).to.be.empty;
+        expect(data[1]).to.be.empty;
+    });
+});


### PR DESCRIPTION
Fixes a reported issue where parsing an empty file would throw an error. This is likely an upstream problem with typescript/vfs, but this PR instead gracefully handles this edge case by returning early.

Includes tests for empty files