### PR TITLE
Removes @microsoft/tsdoc dependancy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@playcanvas/attribute-parser",
       "version": "1.3.2",
       "dependencies": {
-        "@microsoft/tsdoc": "^0.15.0",
         "@playcanvas/eslint-config": "^1.7.4 || ^2.0.0",
         "@typescript/vfs": "^1.6.0",
         "eslint": "^8.56.0 || ^9.0.0",
@@ -229,11 +228,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@microsoft/tsdoc": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
-      "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "version": "1.3.2",
   "dependencies": {
-    "@microsoft/tsdoc": "^0.15.0",
     "@playcanvas/eslint-config": "^1.7.4 || ^2.0.0",
     "@typescript/vfs": "^1.6.0",
     "eslint": "^8.56.0 || ^9.0.0",

--- a/src/utils/attribute-utils.js
+++ b/src/utils/attribute-utils.js
@@ -4,10 +4,10 @@
 
 
 /**
- * Returns a tsdoc tag from a JSDoc comment.
+ * Returns a jsdoc tag from a JSDoc comment.
  * @param {string} tag - The tag to search for
  * @param {import('typescript').Node} doc - The JSDoc comment node
- * @returns {import('@microsoft/tsdoc').DocNode | null} - The tag node
+ * @returns {import('typescript').Node} | null} - The tag node
  */
 export const getTagFromJsdoc = (tag, doc) => {
     return doc?.tags?.find(doc => doc.tagName.text === tag);
@@ -42,29 +42,3 @@ export const hasTag = (tag, node) => {
 export const isInterface = (node) => {
     return hasTag('interface', node);
 };
-
-// /**
-//  * Parses a type tag in the format "{type}".
-//  * @param {import('@microsoft/tsdoc').DocSection} content - The content of the tag.
-//  * @param {object} metadata - An object to store the extracted metadata.
-//  * @param {{ node: import('typescript').Node, env: tsdoc.Environment, errors: string[] }} opts - Additional parser options
-//  * @returns {{ type: import('typescript').Type | null, array: boolean | null }} - The extracted type and array flag.
-//  */
-// export function parseTypeTag(content, metadata, { node, env, errors }) {
-
-//     // Extract the full source text of the original file
-//     const originalSourceText = node.getSourceFile().getFullText();
-//     const typeString = extractTextFromDocNode(content);
-//     const sourceText = `${originalSourceText}\nlet a: ${typeString};`;
-
-//     env.createFile("/virtual.ts", sourceText);
-
-//     const updatedProgram = env.languageService.getProgram();
-//     const newTypeChecker = updatedProgram.getTypeChecker();
-
-//     const sourceFile = updatedProgram.getSourceFile('/virtual.ts');
-
-//     const variableStatement = sourceFile.statements[sourceFile.statements.length - 1];
-//     const variableDeclaration = variableStatement.declarationList.declarations[0];
-//     return getType(variableDeclaration, newTypeChecker);
-// }


### PR DESCRIPTION
This PR refactors to remove the dependancy on **`@microsoft/tsdoc`**.  This has a number of benefits

- Reduces code complexity
- Reduces bundled size
- Improves parsing time (~10%)
- Removes [circular dependancy](https://github.com/playcanvas/editor-ui/blob/6260865a601e6f4741643fa741246c201ec5430c/rollup.config.mjs#L125-L138) which should help bundling