### PR TITLE
Support `@visibleif` and `@enabledif` tags

### DIFF
--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -147,7 +147,9 @@ const SUPPORTED_BLOCK_TAGS = new Map([
     ['size', 'number'],
     ['step', 'number'],
     ['title', 'string'],
-    ['default', 'any']
+    ['default', 'any'],
+    ['enabledWhen', 'any'],
+    ['visibleWhen', 'any']
 ]);
 
 /**
@@ -200,6 +202,16 @@ const mapAttributesToOutput = (attribute) => {
     // Curve Attributes specifically should not expose a default value if it's an empty array
     if (attribute.type === 'curve' && Array.isArray(attribute.value) && attribute.value.length === 0) {
         delete attribute.default;
+    }
+
+    // enabledWhen is in a {}, so strip it out
+    if (attribute.enabledWhen?.startsWith('{') && attribute.enabledWhen?.endsWith('}')) {
+        attribute.enabledWhen = attribute.enabledWhen.slice(1, -1);
+    }
+
+    // enabledWhen is in a {}, so strip it out
+    if (attribute.visibleWhen?.startsWith('{') && attribute.visibleWhen?.endsWith('}')) {
+        attribute.visibleWhen = attribute.visibleWhen.slice(1, -1);
     }
 
     // remove typeName from the output

--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -148,8 +148,8 @@ const SUPPORTED_BLOCK_TAGS = new Map([
     ['step', 'number'],
     ['title', 'string'],
     ['default', 'any'],
-    ['enabledWhen', 'any'],
-    ['visibleWhen', 'any']
+    ['enabledif', 'any'],
+    ['visibleif', 'any']
 ]);
 
 /**
@@ -204,14 +204,14 @@ const mapAttributesToOutput = (attribute) => {
         delete attribute.default;
     }
 
-    // enabledWhen is in a {}, so strip it out
-    if (attribute.enabledWhen?.startsWith('{') && attribute.enabledWhen?.endsWith('}')) {
-        attribute.enabledWhen = attribute.enabledWhen.slice(1, -1);
+    // enabledif is in a {}, so strip it out
+    if (attribute.enabledif?.startsWith('{') && attribute.enabledif?.endsWith('}')) {
+        attribute.enabledif = attribute.enabledif.slice(1, -1);
     }
 
-    // enabledWhen is in a {}, so strip it out
-    if (attribute.visibleWhen?.startsWith('{') && attribute.visibleWhen?.endsWith('}')) {
-        attribute.visibleWhen = attribute.visibleWhen.slice(1, -1);
+    // enabledif is in a {}, so strip it out
+    if (attribute.visibleif?.startsWith('{') && attribute.visibleif?.endsWith('}')) {
+        attribute.visibleif = attribute.visibleif.slice(1, -1);
     }
 
     // remove typeName from the output

--- a/test/fixtures/conditional.valid.js
+++ b/test/fixtures/conditional.valid.js
@@ -3,13 +3,13 @@ import { Script } from 'playcanvas';
 class Example extends Script {
     /**
      * @attribute
-     * @visibleWhen {b === 2}
+     * @visibleif {b === 2}
      */
     a = 1;
 
     /**
      * @attribute
-     * @enabledWhen {a === 3}
+     * @enabledif {a === 3}
      */
     b = 1;
 

--- a/test/fixtures/conditional.valid.js
+++ b/test/fixtures/conditional.valid.js
@@ -1,0 +1,22 @@
+import { Script } from 'playcanvas';
+
+class Example extends Script {
+    /**
+     * @attribute
+     * @visibleWhen {b === 2}
+     */
+    a = 1;
+
+    /**
+     * @attribute
+     * @enabledWhen {a === 3}
+     */
+    b = 1;
+
+    /**
+     * @attribute
+     */
+    c = 1;
+}
+
+export { Example };

--- a/test/tests/valid/conditional.test.js
+++ b/test/tests/valid/conditional.test.js
@@ -21,25 +21,25 @@ describe('VALID: Conditional Tags', function () {
         expect(data[0].example.errors).to.be.empty;
     });
 
-    it('a: should conditional `@visibleWhen` tag', function () {
+    it('a: should conditional `@visibleif` tag', function () {
         expect(data[0].example.attributes.a).exist;
         expect(data[0].example.attributes.a.name).to.equal('a');
         expect(data[0].example.attributes.a.type).to.equal('number');
-        expect(data[0].example.attributes.a.visibleWhen).to.equal('b === 2');
+        expect(data[0].example.attributes.a.visibleif).to.equal('b === 2');
     });
 
-    it('b: should conditional `@enabledWhen` tag', function () {
+    it('b: should conditional `@enabledif` tag', function () {
         expect(data[0].example.attributes.b).exist;
         expect(data[0].example.attributes.b.name).to.equal('b');
         expect(data[0].example.attributes.b.type).to.equal('number');
-        expect(data[0].example.attributes.b.enabledWhen).to.equal('a === 3');
+        expect(data[0].example.attributes.b.enabledif).to.equal('a === 3');
     });
 
-    it('c: should not include `@enabledWhen` or `@visibleWhen` tag if none is declared', function () {
+    it('c: should not include `@enabledif` or `@visibleif` tag if none is declared', function () {
         expect(data[0].example.attributes.c).exist;
         expect(data[0].example.attributes.c.name).to.equal('c');
         expect(data[0].example.attributes.c.type).to.equal('number');
-        expect(data[0].example.attributes.c.enabledWhen).to.not.exist;
-        expect(data[0].example.attributes.c.visibleWhen).to.not.exist;
+        expect(data[0].example.attributes.c.enabledif).to.not.exist;
+        expect(data[0].example.attributes.c.visibleif).to.not.exist;
     });
 });

--- a/test/tests/valid/conditional.test.js
+++ b/test/tests/valid/conditional.test.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { describe, it, before } from 'mocha';
+
+import { parseAttributes } from '../../utils.js';
+
+describe('VALID: Conditional Tags', function () {
+    let data;
+    before(async function () {
+        data = await parseAttributes('./conditional.valid.js');
+    });
+
+    it('only results should exist', function () {
+        expect(data).to.exist;
+        expect(data[0]).to.not.be.empty;
+        expect(data[1]).to.be.empty;
+    });
+
+    it('Example: should exist without errors', function () {
+        expect(data[0]?.example).to.exist;
+        expect(data[0].example.attributes).to.not.be.empty;
+        expect(data[0].example.errors).to.be.empty;
+    });
+
+    it('a: should conditional `@visibleWhen` tag', function () {
+        expect(data[0].example.attributes.a).exist;
+        expect(data[0].example.attributes.a.name).to.equal('a');
+        expect(data[0].example.attributes.a.type).to.equal('number');
+        expect(data[0].example.attributes.a.visibleWhen).to.equal('b === 2');
+    });
+
+    it('b: should conditional `@enabledWhen` tag', function () {
+        expect(data[0].example.attributes.b).exist;
+        expect(data[0].example.attributes.b.name).to.equal('b');
+        expect(data[0].example.attributes.b.type).to.equal('number');
+        expect(data[0].example.attributes.b.enabledWhen).to.equal('a === 3');
+    });
+
+    it('c: should not include `@enabledWhen` or `@visibleWhen` tag if none is declared', function () {
+        expect(data[0].example.attributes.c).exist;
+        expect(data[0].example.attributes.c.name).to.equal('c');
+        expect(data[0].example.attributes.c.type).to.equal('number');
+        expect(data[0].example.attributes.c.enabledWhen).to.not.exist;
+        expect(data[0].example.attributes.c.visibleWhen).to.not.exist;
+    });
+});


### PR DESCRIPTION
This PR introduces support for conditional attributes in the script parser. The main changes include adding new attributes, updating the parser to handle these attributes, and adding tests to ensure the functionality works as expected.

See https://github.com/playcanvas/editor/issues/1196 for community discussion.
See https://github.com/playcanvas/editor-ui/pull/499 for editor context

PR also includes tests [`test/tests/valid/conditional.test.js`](diffhunk://#diff-5c76449d40ac5590b40ce7c2a3e8e69f8ade27513e178e615de460b8062e0e11R1-R45)