### PR TITLE
Feat string keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/attribute-parser",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/attribute-parser",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
         "@playcanvas/eslint-config": "^1.7.4 || ^2.0.0",
         "@typescript/vfs": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/attribute-parser",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/attribute-parser",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "dependencies": {
         "@playcanvas/eslint-config": "^1.7.4 || ^2.0.0",
         "@typescript/vfs": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "version": "1.3.2",
+  "version": "1.3.3",
   "dependencies": {
     "@playcanvas/eslint-config": "^1.7.4 || ^2.0.0",
     "@typescript/vfs": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "version": "1.3.3",
+  "version": "1.4.0",
   "dependencies": {
     "@playcanvas/eslint-config": "^1.7.4 || ^2.0.0",
     "@typescript/vfs": "^1.6.0",

--- a/src/parsers/attribute-parser.js
+++ b/src/parsers/attribute-parser.js
@@ -154,7 +154,7 @@ export class AttributeParser {
 
                         // Check if the declaration is a TypeScript enum
                         if (ts.isEnumDeclaration(declaration)) {
-                            members = declaration.members.map(member => ({ [member.name.getText()]: member.initializer.text }));
+                            members = declaration.members.map(member => ({ [member.name.text]: member.initializer.text }));
                         }
 
                         // Additionally check for JSDoc enum tag
@@ -187,7 +187,8 @@ export class AttributeParser {
             node.properties.forEach((property) => {
 
                 if (ts.isPropertyAssignment(property)) {
-                    const name = property.name && ts.isIdentifier(property.name) && property.name.text;
+                    const isValidName = ts.isIdentifier(property.name) || ts.isStringLiteral(property.name);
+                    const name = isValidName && property.name.text;
                     const value = getLiteralValue(property.initializer, this.typeChecker);
                     members.push({ [name]: value });
                 }

--- a/test/fixtures/enum.valid.js
+++ b/test/fixtures/enum.valid.js
@@ -16,7 +16,8 @@ const NumberEnum = {
 const StringEnum = {
     A: 'a',
     B: 'b',
-    C: 'c'
+    C: 'c',
+    'A string key': 'd'
 };
 
 /**

--- a/test/fixtures/enum.valid.ts
+++ b/test/fixtures/enum.valid.ts
@@ -9,7 +9,8 @@ enum NumberEnum {
 enum StringEnum {
     A = 'a',
     B = 'b',
-    C = 'c'
+    C = 'c',
+    "A string key" = 'd'
 };
 
 enum NumberNumberEnum {

--- a/test/tests/valid/enum.test.js
+++ b/test/tests/valid/enum.test.js
@@ -56,10 +56,11 @@ function runTests(fileName) {
             expect(data[0].example.attributes.h.name).to.equal('h');
             expect(data[0].example.attributes.h.type).to.equal('string');
             expect(data[0].example.attributes.h.array).to.equal(false);
-            expect(data[0].example.attributes.h.enum).to.be.an('array').with.lengthOf(3);
+            expect(data[0].example.attributes.h.enum).to.be.an('array').with.lengthOf(4);
             expect(data[0].example.attributes.h.enum[0]).to.deep.equal({ A: 'a' });
             expect(data[0].example.attributes.h.enum[1]).to.deep.equal({ B: 'b' });
             expect(data[0].example.attributes.h.enum[2]).to.deep.equal({ C: 'c' });
+            expect(data[0].example.attributes.h.enum[3]).to.deep.equal({ 'A string key': 'd' });
             expect(data[0].example.attributes.h.default).to.equal('');
         });
 


### PR DESCRIPTION
Adds support for declaring enums keys as string literals. 

Test included. Fixes https://github.com/playcanvas/editor/issues/1255

```javascript
const MyEnum = {
  "Some String": 10
}
```
and in TS

```typescript
enum MyEnum {
  "Some String": 10
}
```

