### PR TITLE
Fixed issue parsing accessor attributes in reverse order

### DIFF
--- a/test/fixtures/misc.valid.js
+++ b/test/fixtures/misc.valid.js
@@ -40,6 +40,7 @@ class Example extends Script {
         return this._d;
     }
 
+    // eslint-disable-next-line grouped-accessor-pairs
     set d(v) {
         this._d = v;
     }

--- a/test/fixtures/misc.valid.js
+++ b/test/fixtures/misc.valid.js
@@ -12,6 +12,8 @@ class Example extends Script {
 
     _b = 10;
 
+    _d = 10;
+
     /**
      * @attribute
      * @type {number}
@@ -28,6 +30,19 @@ class Example extends Script {
      * @type {number}
      */
     c;
+
+    /**
+     * Reverse order gett/setter accessor
+     * @attribute
+     * @type {number}
+     */
+    get d() {
+        return this._d;
+    }
+
+    set d(v) {
+        this._d = v;
+    }
 }
 
 export { Example };

--- a/test/tests/valid/misc.test.js
+++ b/test/tests/valid/misc.test.js
@@ -43,4 +43,12 @@ describe('VALID: Misc attribute types', function () {
         expect(data[0].example.attributes.c).to.not.exist;
     });
 
+    it('d: should be a numeric attribute with a getter and setter defined in reverse order', function () {
+        expect(data[0].example.attributes.d).to.exist;
+        expect(data[0].example.attributes.d.name).to.equal('d');
+        expect(data[0].example.attributes.d.type).to.equal('number');
+        expect(data[0].example.attributes.d.array).to.equal(false);
+        expect(data[0].example.attributes.d.default).to.equal(0);
+    });
+
 });


### PR DESCRIPTION
Fixes an issue where accessor attributes defined as getter/setters were not parsed and silently ignored.

Tests included. Fixes #34 .

```javascript
class X extends Script {
 // This now works!
  /** @attribute **/
  get someAttr() { }
  set someAttr() { }
  // This works too
  /** @attribute **/
  set someAttr() { }
  get someAttr() { }
} 
```

