### PR TITLE
Parse static scriptName field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playcanvas/attribute-parser",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playcanvas/attribute-parser",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@playcanvas/eslint-config": "^1.7.4 || ^2.0.0",
         "@typescript/vfs": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "dependencies": {
     "@playcanvas/eslint-config": "^1.7.4 || ^2.0.0",
     "@typescript/vfs": "^1.6.0",

--- a/test/fixtures/program.valid.js
+++ b/test/fixtures/program.valid.js
@@ -6,6 +6,8 @@ import { Script } from 'playcanvas';
 export const MyEnum = { value: 0 };
 
 class Example extends Script {
+    static scriptName = 'customExample';
+
     /**
      * @attribute
      * @precision 1

--- a/test/tests/valid/program.test.js
+++ b/test/tests/valid/program.test.js
@@ -9,10 +9,15 @@ describe('VALID: Program ', function () {
         data = await parseAttributes('./program.valid.js');
     });
 
+    it('should have a customExample script', function () {
+        expect(data[0].customExample).to.exist;
+        expect(data[0].customExample.errors).to.be.empty;
+    });
+
     it('only results should exist', function () {
         expect(data).to.exist;
         expect(data[0]).to.not.be.empty;
         expect(data[1]).to.be.empty;
-        expect(data[0].example.errors).to.be.empty;
+        expect(data[0].customExample.errors).to.be.empty;
     });
 });


### PR DESCRIPTION
This pull request introduces a minor version update and enhances the functionality of the JSDoc parser to support custom script names. It also includes corresponding updates to test files to validate the new functionality.

### Enhancements to JSDoc Parser:
* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R146-R165): Added a new helper function `isScriptNameMember` to identify static `scriptName` properties in class declarations. Updated the logic to use the `scriptName` property as the class name if it exists.

### Test Updates:
* [`test/fixtures/program.valid.js`](diffhunk://#diff-1ca23b0c0f21dada26d396c4bd6133d469286dd53ea0957987a8da94b7b8d851R9-R10): Added a `static scriptName` property to the `Example` class to test the new functionality.
* [`test/tests/valid/program.test.js`](diffhunk://#diff-b5cf3915f8244ec2ef471db250184851da4241287ba4ce2b614407510a9705abR12-R21): Added a new test case to verify the presence and correctness of the `customExample` script name. Updated an existing test to check for `customExample` instead of `example`.