### PR TITLE
Support inline object literal attributes

### DIFF
--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -390,7 +390,7 @@ export class ScriptParser {
 
                     // If the type is an interface, we need to parse the attribute comments, if not, just the intitialized object
                     let commentAttributes;
-                    if (typeIsInterface) {
+                    if (typeIsInterface || isInitialized) {
                         commentAttributes = this.extractAttributes(typeNode, { errors, requiresAttributeTag: false, depth: depth + 1 });
                     }
 

--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -388,7 +388,7 @@ export class ScriptParser {
                         Array.from(type.symbol.members).map(arr => arr[1].declarations[0]) ??  // a typedefs property declarations
                         [];
 
-                    // If the type is an interface, we need to parse the attribute comments, if not, just the intitialized object
+                    // If the type is an interface or an initialized object, we need to parse the attribute comments, if not, just the intitialized object
                     let commentAttributes;
                     if (typeIsInterface || isInitialized) {
                         commentAttributes = this.extractAttributes(typeNode, { errors, requiresAttributeTag: false, depth: depth + 1 });

--- a/src/utils/ts-utils.js
+++ b/src/utils/ts-utils.js
@@ -209,6 +209,7 @@ function getSuperClasses(node, typeChecker) {
 export function getJSDocTags(node, typeChecker) {
     const tags = [];
 
+    // check if class interface of initialized object
     if (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) {
         // get an array of the class an all parent classed
         const heritageChain = getSuperClasses(node, typeChecker)
@@ -239,6 +240,23 @@ export function getJSDocTags(node, typeChecker) {
                     }
                 }
             });
+        });
+    } else if (ts.isObjectLiteralExpression(node)) {
+        // Handle object literals
+        node.properties.forEach((property) => {
+            if (ts.isPropertyAssignment(property)) {
+                const memberName = property.name &&
+                    (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) ?
+                    property.name.text :
+                    'unnamed';
+
+                if (property.jsDoc?.length > 0) {
+                    tags.push({
+                        memberName,
+                        member: property
+                    });
+                }
+            }
         });
     }
 

--- a/test/fixtures/json.valid.js
+++ b/test/fixtures/json.valid.js
@@ -6,6 +6,7 @@ import { Script, Vec3 } from 'playcanvas';
 // eslint-disable-next-line
 class Folder {
     /**
+     * This is some description of the attribute.
      * @attribute
      * @type {boolean}
      */
@@ -13,6 +14,7 @@ class Folder {
 
     /**
      * @attribute
+     * @range [10, 20]
      */
     b = 10;
 
@@ -64,7 +66,14 @@ class Example extends Script {
     /**
      * @attribute
      */
-    i = { a: true, b: 10, c: 'hello', d: [new Vec3(1, 2, 3)] };
+    i = {
+        /** description of a */
+        a: true,
+        /** @range [10, 20] */
+        b: 10,
+        c: 'hello',
+        d: [new Vec3(1, 2, 3)]
+    };
 
     /**
      * @typedef {object} TypeDefFolder

--- a/test/fixtures/json.valid.ts
+++ b/test/fixtures/json.valid.ts
@@ -2,6 +2,7 @@ import { Script, Vec3 } from 'playcanvas';
 
 interface Folder {
     /**
+     * This is some description of the attribute.
      * @attribute
      */
     a: boolean;
@@ -9,6 +10,7 @@ interface Folder {
     /**
      * @attribute
      * @default 10
+     * @range [10, 20]
      */
     b: number;
 
@@ -54,7 +56,14 @@ class Example extends Script {
     /**
      * @attribute
      */
-    i = { a: true, b: 10, c: 'hello', d: [new Vec3(1, 2, 3)] };
+    i = {
+        /** description of a */
+        a: true,
+        /** @range [10, 20] */
+        b: 10,
+        c: 'hello',
+        d: [new Vec3(1, 2, 3)]
+    };
 
     /**
      * @attribute

--- a/test/tests/valid/json.test.js
+++ b/test/tests/valid/json.test.js
@@ -37,12 +37,15 @@ describe('JS: VALID: Asset attribute', function () {
         expect(data[0].example.attributes.f.schema[0].type).to.equal('boolean');
         expect(data[0].example.attributes.f.schema[0].array).to.equal(false);
         expect(data[0].example.attributes.f.schema[0].default).to.equal(false);
+        expect(data[0].example.attributes.f.schema[0].description).to.equal('This is some description of the attribute');
     });
 
     it('f[b]: should be a numeric attribute', function () {
         expect(data[0].example.attributes.f.schema[1].name).to.equal('b');
         expect(data[0].example.attributes.f.schema[1].type).to.equal('number');
         expect(data[0].example.attributes.f.schema[1].array).to.equal(false);
+        expect(data[0].example.attributes.f.schema[1].min).to.equal(10);
+        expect(data[0].example.attributes.f.schema[1].max).to.equal(20);
         expect(data[0].example.attributes.f.schema[1].default).to.equal(10);
     });
 
@@ -98,6 +101,22 @@ describe('JS: VALID: Asset attribute', function () {
         expect(data[0].example.attributes.i.default).to.eql(null);
 
         expect(data[0].example.attributes.i.schema).to.exist;
+    });
+
+    it('i[a]: should be a boolean attribute', function () {
+        expect(data[0].example.attributes.i.schema[0].name).to.equal('a');
+        expect(data[0].example.attributes.i.schema[0].type).to.equal('boolean');
+        expect(data[0].example.attributes.i.schema[0].array).to.equal(false);
+        expect(data[0].example.attributes.i.schema[0].default).to.equal(true);
+        expect(data[0].example.attributes.i.schema[0].description).to.equal('description of a');
+    });
+
+    it('i[b]: should be a numeric attribute', function () {
+        expect(data[0].example.attributes.i.schema[1].name).to.equal('b');
+        expect(data[0].example.attributes.i.schema[1].type).to.equal('number');
+        expect(data[0].example.attributes.i.schema[1].array).to.equal(false);
+        expect(data[0].example.attributes.i.schema[1].min).to.equal(10);
+        expect(data[0].example.attributes.i.schema[1].max).to.equal(20);
     });
 
     it('j: should be a typedef json attribute', function () {
@@ -184,6 +203,7 @@ describe('TS: VALID: Asset attribute', function () {
         expect(data[0].example.attributes.f.schema[0].type).to.equal('boolean');
         expect(data[0].example.attributes.f.schema[0].array).to.equal(false);
         expect(data[0].example.attributes.f.schema[0].default).to.equal(false);
+        expect(data[0].example.attributes.f.schema[0].description).to.equal('This is some description of the attribute');
     });
 
     it('f[b]: should be a numeric attribute', function () {
@@ -191,6 +211,8 @@ describe('TS: VALID: Asset attribute', function () {
         expect(data[0].example.attributes.f.schema[1].type).to.equal('number');
         expect(data[0].example.attributes.f.schema[1].array).to.equal(false);
         expect(data[0].example.attributes.f.schema[1].default).to.equal(10);
+        expect(data[0].example.attributes.f.schema[1].min).to.equal(10);
+        expect(data[0].example.attributes.f.schema[1].max).to.equal(20);
     });
 
     it('f[c]: should be a string attribute', function () {
@@ -245,6 +267,22 @@ describe('TS: VALID: Asset attribute', function () {
         expect(data[0].example.attributes.i.default).to.eql(null);
 
         expect(data[0].example.attributes.i.schema).to.exist;
+    });
+
+    it('i[a]: should be a boolean attribute', function () {
+        expect(data[0].example.attributes.i.schema[0].name).to.equal('a');
+        expect(data[0].example.attributes.i.schema[0].type).to.equal('boolean');
+        expect(data[0].example.attributes.i.schema[0].array).to.equal(false);
+        expect(data[0].example.attributes.i.schema[0].default).to.equal(true);
+        expect(data[0].example.attributes.i.schema[0].description).to.equal('description of a');
+    });
+
+    it('i[b]: should be a numeric attribute', function () {
+        expect(data[0].example.attributes.i.schema[1].name).to.equal('b');
+        expect(data[0].example.attributes.i.schema[1].type).to.equal('number');
+        expect(data[0].example.attributes.i.schema[1].array).to.equal(false);
+        expect(data[0].example.attributes.i.schema[1].min).to.equal(10);
+        expect(data[0].example.attributes.i.schema[1].max).to.equal(20);
     });
 
     it('l: should be an inline type json attribute', function () {


### PR DESCRIPTION
This PR updates the parsing to handle nested attributes better

**Before (nested attributes require @interface):**

```jsx
import { Script } from 'playcanvas'

/** @interface */
class JSON {
   /** 
    * Some important description
    * @range [0, 10] 
    */
   num = 10
}

class Test extends Script {
  /** 
   * @attribute 
   * @type {JSON}
   */
  json
}
```

Object literals were supported but their metadata like `@range` or description were not included (See #38)

**This has now been updated to support object literals:**

```jsx
import { Script } from 'playcanvas'

class Test extends Script {
  /** @attribute */
  json = {
   /** 
    * Some important description
    * @range [0, 10] 
    */
    num = 10
  }
}
```

Tests included. Fixes #38 
