### PR TITLE
Feat multi sentence description

### DIFF
--- a/src/parsers/attribute-parser.js
+++ b/src/parsers/attribute-parser.js
@@ -46,7 +46,7 @@ export class AttributeParser {
             if (!attribute) return;
 
             // Extract the description from the summary section
-            attribute.description = node.jsDoc[0].comment;
+            attribute.description = node.jsDoc?.[0]?.comment || '';
 
             // Extract metadata from custom tags
             const jsDocTags = node.jsDoc?.[0]?.tags ?? [];

--- a/src/parsers/attribute-parser.js
+++ b/src/parsers/attribute-parser.js
@@ -46,10 +46,7 @@ export class AttributeParser {
             if (!attribute) return;
 
             // Extract the description from the summary section
-            const description = node.jsDoc[0].comment;
-            if (description) {
-                attribute.description = description.split('.')[0];
-            }
+            attribute.description = node.jsDoc[0].comment;
 
             // Extract metadata from custom tags
             const jsDocTags = node.jsDoc?.[0]?.tags ?? [];

--- a/test/fixtures/misc.valid.js
+++ b/test/fixtures/misc.valid.js
@@ -2,7 +2,9 @@ import { Script } from 'playcanvas';
 
 class Example extends Script {
     /**
-     * This is a description of the attribute.
+     * This is a description of the attribute. It can be multi-sentence.
+     *
+     * And multi-line too
      *
      * @attribute
      * @type {number}

--- a/test/tests/valid/json.test.js
+++ b/test/tests/valid/json.test.js
@@ -37,7 +37,7 @@ describe('JS: VALID: Asset attribute', function () {
         expect(data[0].example.attributes.f.schema[0].type).to.equal('boolean');
         expect(data[0].example.attributes.f.schema[0].array).to.equal(false);
         expect(data[0].example.attributes.f.schema[0].default).to.equal(false);
-        expect(data[0].example.attributes.f.schema[0].description).to.equal('This is some description of the attribute');
+        expect(data[0].example.attributes.f.schema[0].description).to.equal('This is some description of the attribute.');
     });
 
     it('f[b]: should be a numeric attribute', function () {
@@ -203,7 +203,7 @@ describe('TS: VALID: Asset attribute', function () {
         expect(data[0].example.attributes.f.schema[0].type).to.equal('boolean');
         expect(data[0].example.attributes.f.schema[0].array).to.equal(false);
         expect(data[0].example.attributes.f.schema[0].default).to.equal(false);
-        expect(data[0].example.attributes.f.schema[0].description).to.equal('This is some description of the attribute');
+        expect(data[0].example.attributes.f.schema[0].description).to.equal('This is some description of the attribute.');
     });
 
     it('f[b]: should be a numeric attribute', function () {

--- a/test/tests/valid/misc.test.js
+++ b/test/tests/valid/misc.test.js
@@ -28,7 +28,7 @@ describe('VALID: Misc attribute types', function () {
         expect(data[0].example.attributes.a.array).to.equal(false);
         expect(data[0].example.attributes.a.default).to.equal(0);
         expect(data[0].example.attributes.a.title).to.equal('A number');
-        expect(data[0].example.attributes.a.description).to.equal('This is a description of the attribute');
+        expect(data[0].example.attributes.a.description).to.equal('This is a description of the attribute. It can be multi-sentence.\n\nAnd multi-line too');
     });
 
     it('b: should be a numeric attribute with a getter and setter', function () {


### PR DESCRIPTION
Returns the full attribute description without clipping to the first full stop.

Fixes #39. Tests updated