### PR TITLE
Returns correct asset sub type

### DIFF
--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -186,6 +186,11 @@ const mapAttributesToOutput = (attribute) => {
         attribute.type = 'rgba';
     }
 
+    if (attribute.resource) {
+        attribute.assetType = attribute.resource;
+        delete attribute.resource;
+    }
+
     // remove enum if it's empty
     if (attribute.enum.length === 0) delete attribute.enum;
 

--- a/test/tests/invalid/asset.test.js
+++ b/test/tests/invalid/asset.test.js
@@ -26,7 +26,7 @@ describe('INVALID: Asset attribute', function () {
         expect(data[0].example.attributes.a.name).to.equal('a');
         expect(data[0].example.attributes.a.type).to.equal('asset');
         expect(data[0].example.attributes.a.default).to.not.exist;
-        expect(data[0].example.attributes.a.resource).to.not.exist;
+        expect(data[0].example.attributes.a.assetType).to.not.exist;
     });
 
     it('b: should fallback to an asset attribute without resource', function () {
@@ -34,7 +34,7 @@ describe('INVALID: Asset attribute', function () {
         expect(data[0].example.attributes.b.name).to.equal('b');
         expect(data[0].example.attributes.b.type).to.equal('asset');
         expect(data[0].example.attributes.b.default).to.not.exist;
-        expect(data[0].example.attributes.b.resource).to.not.exist;
+        expect(data[0].example.attributes.b.assetType).to.not.exist;
     });
 
     it('c: should fallback to an asset attribute without resource', function () {
@@ -42,6 +42,6 @@ describe('INVALID: Asset attribute', function () {
         expect(data[0].example.attributes.c.name).to.equal('c');
         expect(data[0].example.attributes.c.type).to.equal('asset');
         expect(data[0].example.attributes.c.default).to.not.exist;
-        expect(data[0].example.attributes.c.resource).to.not.exist;
+        expect(data[0].example.attributes.c.assetType).to.not.exist;
     });
 });

--- a/test/tests/valid/asset.test.js
+++ b/test/tests/valid/asset.test.js
@@ -40,7 +40,7 @@ function runTests(fileName) {
             expect(data[0].example.attributes.b.type).to.equal('asset');
             expect(data[0].example.attributes.b.array).to.equal(false);
             expect(data[0].example.attributes.b.default).to.equal(null);
-            expect(data[0].example.attributes.b.resource).to.equal('texture');
+            expect(data[0].example.attributes.b.assetType).to.equal('texture');
         });
 
         it('c: should be a asset attribute array with a container resource', function () {
@@ -49,7 +49,7 @@ function runTests(fileName) {
             expect(data[0].example.attributes.c.type).to.equal('asset');
             expect(data[0].example.attributes.c.array).to.equal(true);
             expect(data[0].example.attributes.c.default).to.equal(null);
-            expect(data[0].example.attributes.c.resource).to.equal('container');
+            expect(data[0].example.attributes.c.assetType).to.equal('container');
         });
 
     });


### PR DESCRIPTION
PR to ensure the correct key is used for the asset sub type. This ensures it's correctly handled by the editor. 

Fixes https://github.com/playcanvas/editor/issues/1313