### PR TITLE
Ignore static members in `getAttributes`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { createSystem, createDefaultMapFromNodeModules, createVirtualTypeScriptE
 import * as ts from 'typescript';
 
 import { ScriptParser } from './parsers/script-parser.js';
-import { isInterface } from './utils/attribute-utils.js';
+import { isInterface, isStaticMember } from './utils/attribute-utils.js';
 import { createDefaultMapFromCDN, flatMapAnyNodes, getExportedNodes, getType, inheritsFrom, isAliasedClassDeclaration } from './utils/ts-utils.js';
 
 const toLowerCamelCase = str => str[0].toLowerCase() + str.substring(1);
@@ -147,7 +147,7 @@ export class JSDocParser {
             ts.isPropertyDeclaration(member) && // Is a property declaration
             ts.isIdentifier(member.name) &&
             member.name.text === 'scriptName' &&
-            (ts.getCombinedModifierFlags(member) & ts.ModifierFlags.Static) !== 0 &&
+            isStaticMember(member) &&
             ts.isStringLiteral(member.initializer)
         );
 
@@ -235,7 +235,7 @@ export class JSDocParser {
             const members = [];
 
             for (const member of node.members) {
-                if (member.kind !== ts.SyntaxKind.PropertyDeclaration) {
+                if (member.kind !== ts.SyntaxKind.PropertyDeclaration || isStaticMember(member)) {
                     continue;
                 }
 
@@ -271,3 +271,4 @@ export class JSDocParser {
         return [results, errors];
     }
 }
+

--- a/src/index.js
+++ b/src/index.js
@@ -271,4 +271,3 @@ export class JSDocParser {
         return [results, errors];
     }
 }
-

--- a/src/utils/attribute-utils.js
+++ b/src/utils/attribute-utils.js
@@ -50,4 +50,4 @@ export const isInterface = (node) => {
  * @param {import('typescript').Node} member - The node to analyze
  * @returns {boolean} - True if the node is a scriptName property
  */
-export const isStaticMember = member => (getCombinedModifierFlags(member) & ModifierFlags.Static) !== 0
+export const isStaticMember = member => (getCombinedModifierFlags(member) & ModifierFlags.Static) !== 0;

--- a/src/utils/attribute-utils.js
+++ b/src/utils/attribute-utils.js
@@ -1,3 +1,5 @@
+import { getCombinedModifierFlags, ModifierFlags } from 'typescript';
+
 /**
  * @file Utility functions for parsing Script attributes.
  */
@@ -42,3 +44,10 @@ export const hasTag = (tag, node) => {
 export const isInterface = (node) => {
     return hasTag('interface', node);
 };
+
+/**
+ * Checks if a node is a scriptName property
+ * @param {import('typescript').Node} member - The node to analyze
+ * @returns {boolean} - True if the node is a scriptName property
+ */
+export const isStaticMember = member => (getCombinedModifierFlags(member) & ModifierFlags.Static) !== 0

--- a/test/fixtures/intellisense.valid.js
+++ b/test/fixtures/intellisense.valid.js
@@ -14,6 +14,9 @@ class Folder {
 }
 
 export class Example extends Script {
+
+    static scriptName = 'Example';
+
     /**
      * @attribute
      */

--- a/test/tests/valid/intellisense.test.js
+++ b/test/tests/valid/intellisense.test.js
@@ -20,6 +20,10 @@ describe('VALID: Intellisense Parsing', function () {
         expect(data[0]?.example).to.exist;
     });
 
+    it('does not return static members', function () {
+        expect(data[0].example[0].name).to.not.equal('scriptName');
+    });
+
     it('attributes have correct types', function () {
         expect(data[0].folder[0].type).to.equal('any');
         expect(data[0].folder[1].type).to.equal('number');


### PR DESCRIPTION
This PR ensures static class members are not returned in the `getAttributes()` function. This ensures the editor does not recommend promoting static fields to attributes. Fixes https://github.com/playcanvas/editor/issues/1310

- Introduced isStaticMember function to check for static properties in TypeScript nodes.
- Updated JSDocParser to use isStaticMember for identifying static scriptName properties.
- Enhanced tests to ensure static members are not returned in the parsed data.