### PR TITLE
Fix range error

### DIFF
--- a/src/parsers/attribute-parser.js
+++ b/src/parsers/attribute-parser.js
@@ -52,7 +52,7 @@ export class AttributeParser {
             const jsDocTags = node.jsDoc?.[0]?.tags ?? [];
             jsDocTags.forEach((tag) => {
                 // Only use the first line of the comment
-                let commentText = tag.comment?.split('\n')[0] || '';
+                let commentText = (tag.comment?.split('\n')[0] || '').trim();
 
                 // Check if the tag is a supported tag
                 if (this.tagTypeAnnotations.has(tag.tagName.text)) {

--- a/src/parsers/attribute-parser.js
+++ b/src/parsers/attribute-parser.js
@@ -51,7 +51,8 @@ export class AttributeParser {
             // Extract metadata from custom tags
             const jsDocTags = node.jsDoc?.[0]?.tags ?? [];
             jsDocTags.forEach((tag) => {
-                let commentText = tag.comment;
+                // Only use the first line of the comment
+                let commentText = tag.comment?.split('\n')[0] || '';
 
                 // Check if the tag is a supported tag
                 if (this.tagTypeAnnotations.has(tag.tagName.text)) {

--- a/test/fixtures/numeric.valid.js
+++ b/test/fixtures/numeric.valid.js
@@ -58,6 +58,14 @@ class Example extends Script {
      * @range []
      */
     h;
+
+    /**
+     * @attribute
+     * @type {number}
+     * @range [0, 1]
+     * Summary text after the range should not cause an error
+     */
+    i;
 }
 
 export { Example };

--- a/test/tests/valid/numeric.test.js
+++ b/test/tests/valid/numeric.test.js
@@ -100,4 +100,14 @@ describe('VALID: Numeric attribute', function () {
         expect(data[0].example.attributes.h.max).to.not.exist;
     });
 
+    it('i: should be a numeric attribute with a range, precision and step', function () {
+        expect(data[1]).to.be.empty;
+        expect(data[0].example.attributes.i).to.exist;
+        expect(data[0].example.attributes.i.name).to.equal('i');
+        expect(data[0].example.attributes.i.type).to.equal('number');
+        expect(data[0].example.attributes.i.array).to.equal(false);
+        expect(data[0].example.attributes.i.default).to.equal(0);
+        expect(data[0].example.attributes.i.min).to.equal(0);
+        expect(data[0].example.attributes.i.max).to.equal(1);
+    });
 });


### PR DESCRIPTION
PR fixes the following issue:

When a summary description was included after a `@range` tag, the parsing would fail, with an invalid error

```js
/**
 * @range [0, 1]
 * A summary description after the range tag would be flagged as an error
 */
v = 1
```

**Fix**
Ensure trailing comments are not included when parse the range contents. Tests included