### PR TITLE
Additional name and script ref in error reporting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,8 @@ export class JSDocParser {
                                     endLineNumber: insertPos.line + 1,
                                     endColumn: insertPos.character + 1
                                 }
-                            }
+                            },
+                            finalName
                         )
                     );
                 }
@@ -226,7 +227,7 @@ export class JSDocParser {
         // Extract attributes from each script
         nodes.forEach((node, name) => {
             const opts = results[name] = { attributes: {}, errors: [] };
-            this.parser.extractAttributes(node, opts);
+            this.parser.extractAttributes(node, { ...opts, scriptName: name });
         });
 
         return [results, errors];
@@ -285,7 +286,7 @@ export class JSDocParser {
                     type: type.name + (type.array ? '[]' : ''),
                     start: jsdocNode ? { line: jsdocPos.line + 1, column: jsdocPos.character + 1 } :
                         { line: namePos.line + 1, column: namePos.character + 1 },
-                    end: { line: namePos.line + 1, column: namePos.character + name.length + 1 }
+                    end: { line: namePos.line + 1, column: namePos.character + 1 }
                 });
             }
 

--- a/src/parsers/parsing-error.js
+++ b/src/parsers/parsing-error.js
@@ -11,13 +11,17 @@
  * @param {string} type - The type of the error
  * @param {string} message - The description of the error
  * @param {Fix} [fix] - The fix for the error
+ * @param {string} scriptName - The name of the script this error belongs to (required)
+ * @param {string} [attributeName] - The name of the attribute this error belongs to (optional)
  */
 export class ParsingError {
-    constructor(node, type, message, fix) {
+    constructor(node, type, message, fix, scriptName, attributeName) {
         this.node = node;        // AST node which caused the error
         this.type = type;        // Type of the error
         this.message = message;  // Description of the error
         this.fix = fix;          // Fix for the error
+        this.scriptName = scriptName; // Script name context
+        this.attributeName = attributeName; // Attribute name context (optional)
     }
 
     toString() {
@@ -25,6 +29,8 @@ export class ParsingError {
         const file = this.node.getSourceFile();
         const fileName = file.fileName;
         const start = this.node.getSourceFile().getLineAndCharacterOfPosition(this.node.getStart());
-        return `ParsingError: ${this.message} at ${fileName}:${start.line + 1}:${start.character}`;
+        const location = `${fileName}:${start.line + 1}:${start.character}`;
+        const context = this.attributeName ? ` [${this.scriptName}.${this.attributeName}]` : ` [${this.scriptName}]`;
+        return `ParsingError: ${this.message}${context} at ${location}`;
     }
 }

--- a/src/parsers/parsing-error.js
+++ b/src/parsers/parsing-error.js
@@ -11,7 +11,7 @@
  * @param {string} type - The type of the error
  * @param {string} message - The description of the error
  * @param {Fix} [fix] - The fix for the error
- * @param {string} scriptName - The name of the script this error belongs to (required)
+ * @param {string} [scriptName] - The name of the script this error belongs to (required)
  * @param {string} [attributeName] - The name of the attribute this error belongs to (optional)
  */
 export class ParsingError {

--- a/src/parsers/script-parser.js
+++ b/src/parsers/script-parser.js
@@ -409,7 +409,7 @@ export class ScriptParser {
                     } else {
                         errorMessage = `This attribute has an invalid @type tag. An attribute should be one of the following: ${supportedTypes}.`;
                     }
-                    const error = new ParsingError(member, 'Invalid Type', errorMessage, undefined, node.name.getText(), memberName);
+                    const error = new ParsingError(member, 'Invalid Type', errorMessage, node.name.getText(), memberName, undefined);
                     errors.push(error);
                     continue;
 

--- a/test/tests/valid/export.test.js
+++ b/test/tests/valid/export.test.js
@@ -21,6 +21,12 @@ describe('VALID: Export Script', function () {
         expect(data[1][1].type).to.equal('Missing Script Name');
         expect(data[1][2].type).to.equal('Missing Script Name');
         expect(data[1][3].type).to.equal('Missing Script Name');
+
+        // Ensure scriptName is present on each error
+        expect(data[1][0].scriptName).to.be.a('string');
+        expect(data[1][1].scriptName).to.be.a('string');
+        expect(data[1][2].scriptName).to.be.a('string');
+        expect(data[1][3].scriptName).to.be.a('string');
     });
 
     it('Example: should exist with attributes', function () {


### PR DESCRIPTION
This PR enhances error reporting and context handling throughout the attribute and script parsing logic. The main focus is on propagating `scriptName` and `attributeName` information into parsing errors, making debugging and error tracing much easier. Additionally, some minor bug fixes and improvements are included in how attribute positions are calculated.

- Refactored `ParsingError` to include additional context in error messages, improving clarity on the source of errors.
- Modified `JSDocParser` to pass `scriptName` during attribute extraction, ensuring consistent error reporting across scripts.
- Enhanced tests to verify the presence of `scriptName` in error outputs, ensuring comprehensive error tracking.