### PR TITLE
fix: add a Node build so the parser works under Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/index.js"
+      "node": "./dist/index.node.mjs",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./libs": "./dist/libs.d.ts"
   },
@@ -29,6 +31,7 @@
   },
   "files": [
     "dist/index.js",
+    "dist/index.node.mjs",
     "dist/libs.d.ts",
     "types",
     "README.md",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,7 +16,18 @@ const types = knownLibFilesForCompilerOptions({ target: ts.ScriptTarget.ES2023 }
 fs.mkdirSync('dist', { recursive: true });
 fs.writeFileSync('dist/libs.d.ts', types);
 
-export default {
+const swcPlugin = () => swc({
+    swc: {
+        minify: production,
+        env: {
+            loose: true
+        }
+    }
+});
+
+// Browser build: bundles typescript and @typescript/vfs and stubs out node built-ins,
+// for in-browser consumers (e.g. the editor), which supply lib types via a CDN.
+const browser = {
     input: 'src/index.js',
     output: {
         dir: 'dist',
@@ -32,14 +43,28 @@ export default {
             browser: true, // This instructs the plugin to resolve for the browser
             preferBuiltins: false // Prefer the local versions of built-ins instead of Node.js versions
         }),
-        swc({
-            swc: {
-                minify: production,
-                env: {
-                    loose: true
-                }
-            }
-        })
+        swcPlugin()
     ]
-
 };
+
+// Node build: keep typescript and @typescript/vfs external so they load as real node modules
+// (real os/fs/path and a native require). The browser build stubs these out, which breaks
+// createDefaultMapFromNodeModules and TypeScript's getNodeSystem() under node.
+const node = {
+    input: 'src/index.js',
+    external: [/^node:/, 'typescript', '@typescript/vfs'],
+    output: {
+        dir: 'dist',
+        entryFileNames: 'index.node.mjs',
+        format: 'esm'
+    },
+    plugins: [
+        resolve({
+            exportConditions: ['node'],
+            preferBuiltins: true
+        }),
+        swcPlugin()
+    ]
+};
+
+export default [browser, node];


### PR DESCRIPTION
## Problem

The only published bundle (`dist/index.js`) is a **browser** build — `@rollup/plugin-node-resolve` runs with `browser: true` and `preferBuiltins: false`, which stubs Node built-ins (`os`, `fs`, `path`, …) as empty objects.

Imported in Node, it fails in two places:

1. **At import** — the bundled TypeScript runs `getNodeSystem()` (its `isNodeLikeSystem()` check is true under Node) and calls `os.platform()` on the empty stub:
   ```
   TypeError: _os.platform is not a function
       at getNodeSystem (.../attribute-parser/dist/index.js)
   ```
2. **At `init()`** — `@typescript/vfs`'s `createDefaultMapFromNodeModules()` uses a bare `require("path"/"fs")` and `require.resolve("typescript")`, which is `undefined` in ESM scope:
   ```
   ReferenceError: require is not defined
   ```

The browser editor never hits either path (`isNodeLikeSystem()` is false in the browser, and it loads lib types from a CDN), so only Node consumers are affected. The test suite runs against `src/` with the real dependencies, so it passes while the published bundle is broken.

## Fix

Add a second, Node-targeted build and route to it via an `exports` `node` condition:

- **`dist/index.js`** — unchanged browser build (bundles `typescript` + `@typescript/vfs`, stubs built-ins).
- **`dist/index.node.mjs`** — new Node build that keeps `typescript` and `@typescript/vfs` **external**, so they load as real Node modules (real `os`/`fs`/`path`, native `require`). This matches how `src/` and the tests already run.

```jsonc
"exports": {
  ".": {
    "types":   "./types/index.d.ts",
    "node":    "./dist/index.node.mjs",
    "import":  "./dist/index.js",
    "default": "./dist/index.js"
  }
}
```

Browser bundlers (`target: web`) don't apply the `node` condition, so they continue resolving the browser build — no change for the editor.

## Verification

Against the new Node build:

- `import` — no `os.platform` crash
- `await parser.init()` — no `require is not defined`
- `updateProgram([...])` — 0 errors
- `getAllEsmScripts()` — correctly detects a class extending `Script`

`npm run publint` passes.